### PR TITLE
Add note in dev.rst about use of the safe option in urllib.quote_plus()

### DIFF
--- a/rtd/source/dev.rst
+++ b/rtd/source/dev.rst
@@ -249,6 +249,11 @@ Build the request string:
    >>> request_str
    'apikey=plgWJfZK4gyS3mOMTVmjUVg-X-jlWlnfaUJ9GAbBbf9EdM-kAYMmAiLqzzq1ElZLYq_u38zCm0bewzGUdP66mg&command=listUsers&response=json'
       
+.. note:: 
+   If you have API calls which contain * (asterisk) characters, you will need to add the option "safe = '*'" for the URL encoding. 
+   The reason is that Python's urllib will encode * characters by default, while CloudStack's internal encoder does not encode them; 
+   this results in an authentication failure for your API call. In the above you would replace "urllib.quote_plus(request[k])" 
+   with "urllib.quote_plus(request[k], safe='*')".
 
 Compute the signature with hmac, do a 64 bit encoding and a url
 encoding:


### PR DESCRIPTION
There is a mismatch between the URL encoding behavior of Python and CloudStack's internal URL encoder (Java URLEncoder):  Python encodes \* (asterisk) characters, while Java does not. When an API call contains a \* character, an authentication failure will occur because the computed signatures will not agree. 

The solution is to add the option "safe = '*'" to Python's urllib.quote_plus().

NOTE: I can only test this problem on CloudStack version 4.3.2 and I don't have access to later versions where the behavior might be different. But the issue was confirmed by @bhaisaab for Cloudmonkey (see https://github.com/apache/cloudstack-cloudmonkey/pull/11).
