### PR TITLE
Fixed example code replacement of space

### DIFF
--- a/rtd/source/dev.rst
+++ b/rtd/source/dev.rst
@@ -260,7 +260,7 @@ encoding:
 
 .. sourcecode:: bash
       
-   >>> sig_str='&'.join(['='.join([k.lower(),urllib.quote_plus(request[k].lower().replace('+','%20'))])for k in sorted(request.iterkeys())]) 
+   >>> sig_str='&'.join(['='.join([k.lower(),urllib.quote_plus(request[k].lower(),'+%20').replace('+','%20')])for k in sorted(request.iterkeys())]) 
    >>> sig_str 'apikey=plgwjfzk4gys3momtvmjuvg-x-jlwlnfauj9gabbbf9edm-kaymmailqzzq1elzlyq_u38zcm0bewzgudp66mg&command=listusers&response=json'
    >>> sig=hmac.new(secretkey,sig_str,hashlib.sha1)
    >>> sig


### PR DESCRIPTION
Updated example code python command that was not working when I tested the example on a request value that included a space.

Changed placement of nested string manipulations and added "safe" characters of '+' and '%20'.

Old:
"example%20string" -> "example%2520string"
"example string" -> "example+string"
"example+string" -> "example%2520string"

New:
"example%20string" -> "example%20string"
"example string" -> "example%20string"
"example+string" -> "example%20string"